### PR TITLE
fix digestLeaf method signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lazyledger/smt
+
+go 1.14

--- a/smt.go
+++ b/smt.go
@@ -1,196 +1,197 @@
 // Package smt implements a Sparse Merkle tree.
 package smt
 
-import(
-    "hash"
+import (
+	"hash"
 )
 
 const left = 0
 const right = 1
+
 var defaultValue = []byte{0}
 
 // SparseMerkleTree is a Sparse Merkle tree.
 type SparseMerkleTree struct {
-    th treeHasher
-    ms MapStore
-    root []byte
+	th   treeHasher
+	ms   MapStore
+	root []byte
 }
 
 // NewSparseMerkleTree creates a new Sparse Merkle tree on an empty MapStore.
 func NewSparseMerkleTree(ms MapStore, hasher hash.Hash) *SparseMerkleTree {
-    smt := SparseMerkleTree{
-        th: *newTreeHasher(hasher),
-        ms: ms,
-    }
+	smt := SparseMerkleTree{
+		th: *newTreeHasher(hasher),
+		ms: ms,
+	}
 
-    for i := 0; i < smt.depth() - 1; i++ {
-        ms.Put(smt.th.defaultNode(i), append(smt.th.defaultNode(i + 1), smt.th.defaultNode(i + 1)...))
-    }
+	for i := 0; i < smt.depth()-1; i++ {
+		ms.Put(smt.th.defaultNode(i), append(smt.th.defaultNode(i+1), smt.th.defaultNode(i+1)...))
+	}
 
-    ms.Put(smt.th.defaultNode(255), defaultValue)
+	ms.Put(smt.th.defaultNode(255), defaultValue)
 
-    rootValue := append(smt.th.defaultNode(0), smt.th.defaultNode(0)...)
-    rootHash := smt.th.digestNode(smt.th.defaultNode(0), smt.th.defaultNode(0))
-    ms.Put(rootHash, rootValue)
-    smt.SetRoot(rootHash)
+	rootValue := append(smt.th.defaultNode(0), smt.th.defaultNode(0)...)
+	rootHash := smt.th.digestNode(smt.th.defaultNode(0), smt.th.defaultNode(0))
+	ms.Put(rootHash, rootValue)
+	smt.SetRoot(rootHash)
 
-    return &smt
+	return &smt
 }
 
 // ImportSparseMerkleTree imports a Sparse Merkle tree from a non-empty MapStore.
 func ImportSparseMerkleTree(ms MapStore, hasher hash.Hash, root []byte) *SparseMerkleTree {
-    smt := SparseMerkleTree{
-        th: *newTreeHasher(hasher),
-        ms: ms,
-        root: root,
-    }
-    return &smt
+	smt := SparseMerkleTree{
+		th:   *newTreeHasher(hasher),
+		ms:   ms,
+		root: root,
+	}
+	return &smt
 }
 
 // Root gets the root of the tree.
 func (smt *SparseMerkleTree) Root() []byte {
-    return smt.root
+	return smt.root
 }
 
 // SetRoot sets the root of the tree.
 func (smt *SparseMerkleTree) SetRoot(root []byte) {
-    smt.root = root
+	smt.root = root
 }
 
 func (smt *SparseMerkleTree) depth() int {
-    return smt.th.pathSize() * 8
+	return smt.th.pathSize() * 8
 }
 
 // Get gets a key from the tree.
 func (smt *SparseMerkleTree) Get(key []byte) ([]byte, error) {
-    value, err := smt.GetForRoot(key, smt.Root())
-    return value, err
+	value, err := smt.GetForRoot(key, smt.Root())
+	return value, err
 }
 
 // GetForRoot gets a key from the tree at a specific root.
 func (smt *SparseMerkleTree) GetForRoot(key []byte, root []byte) ([]byte, error) {
-    path := smt.th.path(key)
-    currentHash := root
-    for i := 0; i < smt.depth(); i++ {
-        currentValue, err := smt.ms.Get(currentHash)
-        if err != nil {
-            return nil, err
-        }
-        if hasBit(path, i) == right {
-            currentHash = currentValue[smt.th.pathSize():]
-        } else {
-            currentHash = currentValue[:smt.th.pathSize()]
-        }
-    }
+	path := smt.th.path(key)
+	currentHash := root
+	for i := 0; i < smt.depth(); i++ {
+		currentValue, err := smt.ms.Get(currentHash)
+		if err != nil {
+			return nil, err
+		}
+		if hasBit(path, i) == right {
+			currentHash = currentValue[smt.th.pathSize():]
+		} else {
+			currentHash = currentValue[:smt.th.pathSize()]
+		}
+	}
 
-    value, err := smt.ms.Get(currentHash)
-    if err != nil {
-        return nil, err
-    }
+	value, err := smt.ms.Get(currentHash)
+	if err != nil {
+		return nil, err
+	}
 
-    return value, nil
+	return value, nil
 }
 
 // Update sets a new value for a key in the tree, returns the new root, and sets the new current root of the tree.
 func (smt *SparseMerkleTree) Update(key []byte, value []byte) ([]byte, error) {
-    newRoot, err := smt.UpdateForRoot(key, value, smt.Root())
-    if err == nil {
-        smt.SetRoot(newRoot)
-    }
-    return newRoot, err
+	newRoot, err := smt.UpdateForRoot(key, value, smt.Root())
+	if err == nil {
+		smt.SetRoot(newRoot)
+	}
+	return newRoot, err
 }
 
 // UpdateForRoot sets a new value for a key in the tree at a specific root, and returns the new root.
 func (smt *SparseMerkleTree) UpdateForRoot(key []byte, value []byte, root []byte) ([]byte, error) {
-    path := smt.th.path(key)
-    sideNodes, err := smt.sideNodesForRoot(path, root)
-    if err != nil {
-        return nil, err
-    }
+	path := smt.th.path(key)
+	sideNodes, err := smt.sideNodesForRoot(path, root)
+	if err != nil {
+		return nil, err
+	}
 
-    newRoot, err := smt.updateWithSideNodes(path, value, sideNodes)
-    return newRoot, err
+	newRoot, err := smt.updateWithSideNodes(path, value, sideNodes)
+	return newRoot, err
 }
 
 func (smt *SparseMerkleTree) updateWithSideNodes(path []byte, value []byte, sideNodes [][]byte) ([]byte, error) {
-    currentHash := smt.th.digestLeaf(path, value)
-    smt.ms.Put(currentHash, value)
-    currentValue := currentHash
+	currentHash := smt.th.digestLeaf(path, value)
+	smt.ms.Put(currentHash, value)
+	currentValue := currentHash
 
-    for i := smt.depth() - 1; i >= 0; i-- {
-        sideNode := make([]byte, smt.th.pathSize())
-        copy(sideNode, sideNodes[i])
-        if hasBit(path, i) == right {
-            currentValue = append(sideNode, currentValue...)
-            currentHash = smt.th.digestNode(sideNode, currentValue)
-        } else {
-            currentValue = append(currentValue, sideNode...)
-            currentHash = smt.th.digestNode(currentValue, sideNode)
-        }
-        err := smt.ms.Put(currentHash, currentValue)
-        if err != nil {
-            return nil, err
-        }
-        currentValue = currentHash
-    }
+	for i := smt.depth() - 1; i >= 0; i-- {
+		sideNode := make([]byte, smt.th.pathSize())
+		copy(sideNode, sideNodes[i])
+		if hasBit(path, i) == right {
+			currentHash = smt.th.digestNode(sideNode, currentValue)
+			currentValue = append(sideNode, currentValue...)
+		} else {
+			currentHash = smt.th.digestNode(currentValue, sideNode)
+			currentValue = append(currentValue, sideNode...)
+		}
+		err := smt.ms.Put(currentHash, currentValue)
+		if err != nil {
+			return nil, err
+		}
+		currentValue = currentHash
+	}
 
-    return currentHash, nil
+	return currentHash, nil
 }
 
 func (smt *SparseMerkleTree) sideNodesForRoot(path []byte, root []byte) ([][]byte, error) {
-    currentValue, err := smt.ms.Get(root)
-    if err != nil {
-        return nil, err
-    }
+	currentValue, err := smt.ms.Get(root)
+	if err != nil {
+		return nil, err
+	}
 
-    sideNodes := make([][]byte, smt.depth())
-    for i := 0; i < smt.depth(); i++ {
-        if hasBit(path, i) == right {
-            sideNodes[i] = currentValue[:smt.th.pathSize()]
-            currentValue, err = smt.ms.Get(currentValue[smt.th.pathSize():])
-            if err != nil {
-                return nil, err
-            }
-        } else {
-            sideNodes[i] = currentValue[smt.th.pathSize():]
-            currentValue, err = smt.ms.Get(currentValue[:smt.th.pathSize()])
-            if err != nil {
-                return nil, err
-            }
-        }
-    }
+	sideNodes := make([][]byte, smt.depth())
+	for i := 0; i < smt.depth(); i++ {
+		if hasBit(path, i) == right {
+			sideNodes[i] = currentValue[:smt.th.pathSize()]
+			currentValue, err = smt.ms.Get(currentValue[smt.th.pathSize():])
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			sideNodes[i] = currentValue[smt.th.pathSize():]
+			currentValue, err = smt.ms.Get(currentValue[:smt.th.pathSize()])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 
-    return sideNodes, err
+	return sideNodes, err
 }
 
 // Prove generates a Merkle proof for a key.
 func (smt *SparseMerkleTree) Prove(key []byte) ([][]byte, error) {
-    proof, err := smt.ProveForRoot(key, smt.Root())
-    return proof, err
+	proof, err := smt.ProveForRoot(key, smt.Root())
+	return proof, err
 }
 
 // ProveForRoot generates a Merkle proof for a key, at a specific root.
 func (smt *SparseMerkleTree) ProveForRoot(key []byte, root []byte) ([][]byte, error) {
-    sideNodes, err := smt.sideNodesForRoot(smt.th.path(key), root)
-    return sideNodes, err
+	sideNodes, err := smt.sideNodesForRoot(smt.th.path(key), root)
+	return sideNodes, err
 }
 
 // ProveCompact generates a compacted Merkle proof for a key.
 func (smt *SparseMerkleTree) ProveCompact(key []byte) ([][]byte, error) {
-    proof, err := smt.Prove(key)
-    if err != nil {
-        return nil, err
-    }
-    compactedProof, err := CompactProof(proof, smt.th.hasher)
-    return compactedProof, err
+	proof, err := smt.Prove(key)
+	if err != nil {
+		return nil, err
+	}
+	compactedProof, err := CompactProof(proof, smt.th.hasher)
+	return compactedProof, err
 }
 
 // ProveCompactForRoot generates a compacted Merkle proof for a key, at a specific root.
 func (smt *SparseMerkleTree) ProveCompactForRoot(key []byte, root []byte) ([][]byte, error) {
-    proof, err := smt.ProveForRoot(key, root)
-    if err != nil {
-        return nil, err
-    }
-    compactedProof, err := CompactProof(proof, smt.th.hasher)
-    return compactedProof, err
+	proof, err := smt.ProveForRoot(key, root)
+	if err != nil {
+		return nil, err
+	}
+	compactedProof, err := CompactProof(proof, smt.th.hasher)
+	return compactedProof, err
 }

--- a/treehasher.go
+++ b/treehasher.go
@@ -1,57 +1,57 @@
 package smt
 
-import(
-    "hash"
+import (
+	"hash"
 )
 
 var leafPrefix = []byte{0}
 var nodePrefix = []byte{1}
 
 type treeHasher struct {
-    hasher hash.Hash
+	hasher hash.Hash
 }
 
 func newTreeHasher(hasher hash.Hash) *treeHasher {
-    th := treeHasher{
-        hasher: hasher,
-    }
+	th := treeHasher{
+		hasher: hasher,
+	}
 
-    return &th
+	return &th
 }
 
 func (th *treeHasher) digest(data []byte) []byte {
-    th.hasher.Write(data)
-    sum := th.hasher.Sum(nil)
-    th.hasher.Reset()
-    return sum
+	th.hasher.Write(data)
+	sum := th.hasher.Sum(nil)
+	th.hasher.Reset()
+	return sum
 }
 
 func (th *treeHasher) path(key []byte) []byte {
-    return th.digest(key)
+	return th.digest(key)
 }
 
-func (th *treeHasher) digestLeaf(value []byte, path []byte) []byte {
-    th.hasher.Write(leafPrefix)
-    th.hasher.Write(path)
-    th.hasher.Write(value)
-    sum := th.hasher.Sum(nil)
-    th.hasher.Reset()
-    return sum
+func (th *treeHasher) digestLeaf(path []byte, value []byte) []byte {
+	th.hasher.Write(leafPrefix)
+	th.hasher.Write(path)
+	th.hasher.Write(value)
+	sum := th.hasher.Sum(nil)
+	th.hasher.Reset()
+	return sum
 }
 
 func (th *treeHasher) digestNode(leftData []byte, rightData []byte) []byte {
-    th.hasher.Write(nodePrefix)
-    th.hasher.Write(leftData)
-    th.hasher.Write(rightData)
-    sum := th.hasher.Sum(nil)
-    th.hasher.Reset()
-    return sum
+	th.hasher.Write(nodePrefix)
+	th.hasher.Write(leftData)
+	th.hasher.Write(rightData)
+	sum := th.hasher.Sum(nil)
+	th.hasher.Reset()
+	return sum
 }
 
 func (th *treeHasher) pathSize() int {
-    return th.hasher.Size()
+	return th.hasher.Size()
 }
 
 func (th *treeHasher) defaultNode(height int) []byte {
-    return defaultNodes(th.hasher)[height]
+	return defaultNodes(th.hasher)[height]
 }


### PR DESCRIPTION
best reviewed without whitespace changes: https://github.com/lazyledger/smt/pull/3/files?diff=unified&w=1

------

- fix order in `digestLeaf`: otherwise might call `digestLeaf`  with value and path roles mixed up (as happened here)
- another fix related to hashing
- whitespace changes are `go fmt` 

