### PR TITLE
Make go fmt formatting obligatory throughout the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 before_install:
   - go get github.com/mattn/goveralls
 script:
+  - diff -u <(echo -n) <(gofmt -d .)
   - goveralls -v -service=travis-ci


### PR DESCRIPTION
## Motivation

- https://blog.golang.org/gofmt
- https://golang.org/doc/effective_go.html#formatting

----

`diff -u <(echo -n) <(gofmt -d .)` will report exit status 1 if the change contains file that aren't consistently formatted via `go fmt`.This guarantees consistent formatting of the code by every contributor (and automates this check via CI).
e.g. see: seehttps://travis-ci.org/github/lazyledger/smt/builds/702763735

----

**Note**: I did not `go fmt` the whole repo  (the build will fail) and prefer to leave that up to you @musalbas.
If I do it, it would most likely touch every single line.

 
