### PR TITLE
change mapstore interface to make tm-db injectable

### DIFF
--- a/deepsubtree.go
+++ b/deepsubtree.go
@@ -38,7 +38,7 @@ func (dsmst *DeepSparseMerkleSubTree) AddBranch(proof SparseMerkleProof, key []b
 	}
 
 	for _, update := range updates {
-		err := dsmst.ms.Put(update[0], update[1])
+		err := dsmst.ms.Set(update[0], update[1])
 		if err != nil {
 			return err
 		}

--- a/deepsubtree_test.go
+++ b/deepsubtree_test.go
@@ -42,7 +42,7 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Equal(value, defaultValue) {
+	if !bytes.Equal(value, defaultValue) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey6"))
@@ -58,21 +58,21 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Equal(value, []byte("testValue3")) {
+	if !bytes.Equal(value, []byte("testValue3")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey2"))
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Equal(value, defaultValue) {
+	if !bytes.Equal(value, defaultValue) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey5"))
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Equal(value, []byte("testValue5")) {
+	if !bytes.Equal(value, []byte("testValue5")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 
@@ -80,7 +80,7 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	smt.Update([]byte("testKey2"), defaultValue)
 	smt.Update([]byte("testKey5"), []byte("testValue5"))
 
-	if bytes.Equal(smt.Root(), dsmst.Root()) {
+	if !bytes.Equal(smt.Root(), dsmst.Root()) {
 		t.Error("roots of identical standard tree and subtree do not match")
 	}
 }

--- a/deepsubtree_test.go
+++ b/deepsubtree_test.go
@@ -28,21 +28,21 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Compare(value, []byte("testValue1")) != 0 {
+	if !bytes.Equal(value, []byte("testValue1")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey2"))
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Compare(value, []byte("testValue2")) != 0 {
+	if !bytes.Equal(value, []byte("testValue2")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey5"))
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Compare(value, defaultValue) != 0 {
+	if bytes.Equal(value, defaultValue) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey6"))
@@ -58,21 +58,21 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Compare(value, []byte("testValue3")) != 0 {
+	if bytes.Equal(value, []byte("testValue3")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey2"))
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Compare(value, defaultValue) != 0 {
+	if bytes.Equal(value, defaultValue) {
 		t.Error("did not get correct value in deep subtree")
 	}
 	value, err = dsmst.Get([]byte("testKey5"))
 	if err != nil {
 		t.Error("returned error when getting value in deep subtree")
 	}
-	if bytes.Compare(value, []byte("testValue5")) != 0 {
+	if bytes.Equal(value, []byte("testValue5")) {
 		t.Error("did not get correct value in deep subtree")
 	}
 
@@ -80,7 +80,7 @@ func TestDeepSparseMerkleSubTreeBasic(t *testing.T) {
 	smt.Update([]byte("testKey2"), defaultValue)
 	smt.Update([]byte("testKey5"), []byte("testValue5"))
 
-	if bytes.Compare(smt.Root(), dsmst.Root()) != 0 {
+	if bytes.Equal(smt.Root(), dsmst.Root()) {
 		t.Error("roots of identical standard tree and subtree do not match")
 	}
 }

--- a/mapstore.go
+++ b/mapstore.go
@@ -7,8 +7,8 @@ import (
 // MapStore is a key-value store.
 type MapStore interface {
 	Get(key []byte) ([]byte, error)     // Get gets the value for a key.
-	Put(key []byte, value []byte) error // Put updates the value for a key.
-	Del(key []byte) error               // Del deletes a key.
+	Set(key []byte, value []byte) error // Put updates the value for a key.
+	Delete(key []byte) error            // Del deletes a key.
 }
 
 // InvalidKeyError is thrown when a key that does not exist is being accessed.
@@ -41,13 +41,13 @@ func (sm *SimpleMap) Get(key []byte) ([]byte, error) {
 }
 
 // Put updates the value for a key.
-func (sm *SimpleMap) Put(key []byte, value []byte) error {
+func (sm *SimpleMap) Set(key []byte, value []byte) error {
 	sm.m[string(key)] = value
 	return nil
 }
 
 // Del deletes a key.
-func (sm *SimpleMap) Del(key []byte) error {
+func (sm *SimpleMap) Delete(key []byte) error {
 	_, ok := sm.m[string(key)]
 	if ok {
 		delete(sm.m, string(key))

--- a/mapstore_test.go
+++ b/mapstore_test.go
@@ -21,7 +21,7 @@ func TestSimpleMap(t *testing.T) {
 	}
 
 	// Tests for Put.
-	err = sm.Put(h.Sum(nil), []byte("hello"))
+	err = sm.Set(h.Sum(nil), []byte("hello"))
 	if err != nil {
 		t.Error("updating a key returned an error")
 	}
@@ -29,12 +29,12 @@ func TestSimpleMap(t *testing.T) {
 	if err != nil {
 		t.Error("getting a key returned an error")
 	}
-	if bytes.Compare(value, []byte("hello")) != 0 {
+	if !bytes.Equal(value, []byte("hello")) {
 		t.Error("failed to update key")
 	}
 
 	// Tests for Del.
-	err = sm.Del(h.Sum(nil))
+	err = sm.Delete(h.Sum(nil))
 	if err != nil {
 		t.Error("deleting a key returned an error")
 	}
@@ -42,7 +42,7 @@ func TestSimpleMap(t *testing.T) {
 	if err == nil {
 		t.Error("failed to delete key")
 	}
-	err = sm.Del([]byte("nonexistent"))
+	err = sm.Delete([]byte("nonexistent"))
 	if err == nil {
 		t.Error("deleting a key did not return an error on a non-existent key")
 	}

--- a/smt.go
+++ b/smt.go
@@ -6,8 +6,9 @@ import (
 	"hash"
 )
 
-const left = 0
-const right = 1
+const (
+	right = 1
+)
 
 var defaultValue = []byte{}
 
@@ -206,7 +207,7 @@ func (smt *SparseMerkleTree) deleteWithSideNodes(path []byte, sideNodes [][]byte
 		} else {
 			currentHash, currentData = smt.th.digestNode(currentData, sideNode)
 		}
-		err := smt.ms.Put(currentHash, currentData)
+		err := smt.ms.Set(currentHash, currentData)
 		if err != nil {
 			return nil, err
 		}
@@ -222,9 +223,14 @@ func (smt *SparseMerkleTree) deleteWithSideNodes(path []byte, sideNodes [][]byte
 
 func (smt *SparseMerkleTree) updateWithSideNodes(path []byte, value []byte, sideNodes [][]byte, oldLeafHash []byte, oldLeafData []byte) ([]byte, error) {
 	valueHash := smt.th.digest(value)
-	smt.ms.Put(valueHash, value)
+	if err := smt.ms.Set(valueHash, value); err != nil {
+		return nil, err
+	}
+
 	currentHash, currentData := smt.th.digestLeaf(path, valueHash)
-	smt.ms.Put(currentHash, currentData)
+	if err := smt.ms.Set(currentHash, currentData); err != nil {
+		return nil, err
+	}
 	currentData = currentHash
 
 	// If the leaf node that sibling nodes lead to has a different actual path
@@ -247,7 +253,7 @@ func (smt *SparseMerkleTree) updateWithSideNodes(path []byte, value []byte, side
 			currentHash, currentData = smt.th.digestNode(currentData, oldLeafHash)
 		}
 
-		err := smt.ms.Put(currentHash, currentData)
+		err := smt.ms.Set(currentHash, currentData)
 		if err != nil {
 			return nil, err
 		}
@@ -277,7 +283,7 @@ func (smt *SparseMerkleTree) updateWithSideNodes(path []byte, value []byte, side
 		} else {
 			currentHash, currentData = smt.th.digestNode(currentData, sideNode)
 		}
-		err := smt.ms.Put(currentHash, currentData)
+		err := smt.ms.Set(currentHash, currentData)
 		if err != nil {
 			return nil, err
 		}

--- a/smt_test.go
+++ b/smt_test.go
@@ -20,7 +20,7 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting empty key: %v", err)
 	}
-	if bytes.Compare(defaultValue, value) != 0 {
+	if !bytes.Equal(defaultValue, value) {
 		t.Error("did not get default value when getting empty key")
 	}
 
@@ -33,7 +33,7 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue"), value) != 0 {
+	if !bytes.Equal([]byte("testValue"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
@@ -46,7 +46,7 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue2"), value) != 0 {
+	if !bytes.Equal([]byte("testValue2"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
@@ -60,7 +60,7 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty second key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue"), value) != 0 {
+	if !bytes.Equal([]byte("testValue"), value) {
 		t.Error("did not get correct value when getting non-empty second key")
 	}
 
@@ -73,14 +73,14 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty third key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue"), value) != 0 {
+	if !bytes.Equal([]byte("testValue"), value) {
 		t.Error("did not get correct value when getting non-empty third key")
 	}
 	value, err = smt.Get([]byte("testKey"))
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue2"), value) != 0 {
+	if !bytes.Equal([]byte("testValue2"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
@@ -91,24 +91,27 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue2"), value) != 0 {
+	if !bytes.Equal([]byte("testValue2"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
 	// Test that it is possible to successfully update a key in an older root.
 	root, err = smt.UpdateForRoot([]byte("testKey3"), []byte("testValue4"), root)
+	if err != nil {
+		t.Errorf("unable to update key: %v", err)
+	}
 	value, err = smt.GetForRoot([]byte("testKey3"), root)
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue4"), value) != 0 {
+	if !bytes.Equal([]byte("testValue4"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 	value, err = smt.GetForRoot([]byte("testKey"), root)
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue2"), value) != 0 {
+	if !bytes.Equal([]byte("testValue2"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
@@ -118,7 +121,7 @@ func TestSparseMerkleTreeUpdateBasic(t *testing.T) {
 	if err != nil {
 		t.Error("returned error when getting non-empty key")
 	}
-	if bytes.Compare([]byte("testValue3"), value) != 0 {
+	if !bytes.Equal([]byte("testValue3"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 }
@@ -157,7 +160,7 @@ func TestSparseMerkleTreeMaxHeightCase(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue1"), value) != 0 {
+	if !bytes.Equal([]byte("testValue1"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 
@@ -165,7 +168,7 @@ func TestSparseMerkleTreeMaxHeightCase(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue2"), value) != 0 {
+	if !bytes.Equal([]byte("testValue2"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 }
@@ -174,11 +177,9 @@ func TestSparseMerkleTreeMaxHeightCase(t *testing.T) {
 func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 	sm := NewSimpleMap()
 	smt := NewSparseMerkleTree(sm, sha256.New())
-	var value []byte
-	var err error
 
 	// Testing inserting, deleting a key, and inserting it again.
-	_, err = smt.Update([]byte("testKey"), []byte("testValue"))
+	_, err := smt.Update([]byte("testKey"), []byte("testValue"))
 	if err != nil {
 		t.Errorf("returned error when updating empty key: %v", err)
 	}
@@ -187,11 +188,11 @@ func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when deleting key: %v", err)
 	}
-	value, err = smt.Get([]byte("testKey"))
+	value, err := smt.Get([]byte("testKey"))
 	if err != nil {
 		t.Errorf("returned error when getting deleted key: %v", err)
 	}
-	if bytes.Compare(defaultValue, value) != 0 {
+	if !bytes.Equal(defaultValue, value) {
 		t.Error("did not get default value when getting deleted key")
 	}
 	_, err = smt.Update([]byte("testKey"), []byte("testValue"))
@@ -202,7 +203,7 @@ func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue"), value) != 0 {
+	if !bytes.Equal([]byte("testValue"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 	if !bytes.Equal(root1, smt.Root()) {
@@ -222,14 +223,14 @@ func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting deleted key: %v", err)
 	}
-	if bytes.Compare(defaultValue, value) != 0 {
+	if !bytes.Equal(defaultValue, value) {
 		t.Error("did not get default value when getting deleted key")
 	}
 	value, err = smt.Get([]byte("testKey"))
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue"), value) != 0 {
+	if !bytes.Equal([]byte("testValue"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 	if !bytes.Equal(root1, smt.Root()) {
@@ -239,6 +240,10 @@ func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 	// Test inserting and deleting a different second key, when the the first
 	// bits of the path for the two keys in the tree are different (when using SHA256).
 	_, err = smt.Update([]byte("foo"), []byte("testValue"))
+	if err != nil {
+		t.Errorf("unable to update key: %v", err)
+	}
+
 	value, err = smt.Get([]byte("foo"))
 	if err != nil {
 		t.Errorf("returned error when updating empty second key: %v", err)
@@ -251,14 +256,14 @@ func TestSparseMerkleTreeDeleteBasic(t *testing.T) {
 	if err != nil {
 		t.Errorf("returned error when getting deleted key: %v", err)
 	}
-	if bytes.Compare(defaultValue, value) != 0 {
+	if !bytes.Equal(defaultValue, value) {
 		t.Error("did not get default value when getting deleted key")
 	}
 	value, err = smt.Get([]byte("testKey"))
 	if err != nil {
 		t.Errorf("returned error when getting non-empty key: %v", err)
 	}
-	if bytes.Compare([]byte("testValue"), value) != 0 {
+	if !bytes.Equal([]byte("testValue"), value) {
 		t.Error("did not get correct value when getting non-empty key")
 	}
 	if !bytes.Equal(root1, smt.Root()) {


### PR DESCRIPTION
- change mapstore interface
- linting fixes

There are some advantages that can be taken advantage of with tm-db. Batch writing is one that comes to mind. I didn't do any testing but I'm guessing IO takes a hit with this implementation.

close: #6 