### PR TITLE
Use integer division instead of floating-point division

### DIFF
--- a/proofs.go
+++ b/proofs.go
@@ -70,7 +70,7 @@ func (proof *SparseCompactMerkleProof) sanityCheck(th *treeHasher) bool {
 
 		// Compact proofs: check that the length of the bit mask is as expected
 		// according to NumSideNodes.
-		len(proof.BitMask) != (proof.NumSideNodes+8-1)/8 ||
+		len(proof.BitMask) != roundUpDivision(proof.NumSideNodes, 8) ||
 
 		// Compact proofs: check that the correct number of sidenodes have been
 		// supplied according to the bit mask.
@@ -162,7 +162,7 @@ func CompactProof(proof SparseMerkleProof, hasher hash.Hash) (SparseCompactMerkl
 		return SparseCompactMerkleProof{}, errors.New("bad proof")
 	}
 
-	bitMask := emptyBytes((len(proof.SideNodes) + 8 - 1) / 8)
+	bitMask := emptyBytes(roundUpDivision(len(proof.SideNodes), 8))
 	var compactedSideNodes [][]byte
 	for i := 0; i < len(proof.SideNodes); i++ {
 		node := make([]byte, th.hasher.Size())

--- a/proofs.go
+++ b/proofs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"hash"
-	"math"
 )
 
 // SparseMerkleProof is a Merkle proof for an element in a SparseMerkleTree.
@@ -71,7 +70,7 @@ func (proof *SparseCompactMerkleProof) sanityCheck(th *treeHasher) bool {
 
 		// Compact proofs: check that the length of the bit mask is as expected
 		// according to NumSideNodes.
-		len(proof.BitMask) != int(math.Ceil(float64(proof.NumSideNodes)/float64(8))) ||
+		len(proof.BitMask) != (proof.NumSideNodes+8-1)/8 ||
 
 		// Compact proofs: check that the correct number of sidenodes have been
 		// supplied according to the bit mask.
@@ -163,7 +162,7 @@ func CompactProof(proof SparseMerkleProof, hasher hash.Hash) (SparseCompactMerkl
 		return SparseCompactMerkleProof{}, errors.New("bad proof")
 	}
 
-	bitMask := emptyBytes(int(math.Ceil(float64(len(proof.SideNodes)) / float64(8))))
+	bitMask := emptyBytes((len(proof.SideNodes) + 8 - 1) / 8)
 	var compactedSideNodes [][]byte
 	for i := 0; i < len(proof.SideNodes); i++ {
 		node := make([]byte, th.hasher.Size())

--- a/utils.go
+++ b/utils.go
@@ -39,3 +39,11 @@ func emptyBytes(length int) []byte {
 	b := make([]byte, length)
 	return b
 }
+
+func roundUpDivision(a int, b int) int {
+	result := a / b
+	if a%b != 0 {
+		result++
+	}
+	return result
+}


### PR DESCRIPTION
Instead of rounding up by converting to float then back to int, do rounding-up integer division directly.

Based on https://stackoverflow.com/a/17974.