### PR TITLE
Set proof's NonMembershipLeafData to nil for membership proofs

### DIFF
--- a/proofs.go
+++ b/proofs.go
@@ -13,7 +13,8 @@ type SparseMerkleProof struct {
 	SideNodes [][]byte
 
 	// NonMembershipLeafData is the data of the unrelated leaf at the position
-	// of the key being proven, in the case of a non-membership proof.
+	// of the key being proven, in the case of a non-membership proof. For
+	// membership proofs, is nil.
 	NonMembershipLeafData []byte
 }
 

--- a/smt.go
+++ b/smt.go
@@ -390,9 +390,12 @@ func (smt *SparseMerkleTree) ProveForRoot(key []byte, root []byte) (SparseMerkle
 	// value, we do not need to add anything else to the proof.
 	var nonMembershipLeafData []byte
 	if !bytes.Equal(leafHash, smt.th.placeholder()) {
-		// This is a non-membership proof that involves showing a different leaf.
-		// Add the leaf data to the proof.
-		nonMembershipLeafData = leafData
+		actualPath, _ := smt.th.parseLeaf(leafData)
+		if !bytes.Equal(actualPath, path) {
+			// This is a non-membership proof that involves showing a different leaf.
+			// Add the leaf data to the proof.
+			nonMembershipLeafData = leafData
+		}
 	}
 
 	proof := SparseMerkleProof{


### PR DESCRIPTION
Currently, the proof's `NonMembershipLeafData` field is always set to the leaf data, even if the proof ends up being a membership proof. Correct this and update documentation to make it clear that membership proofs have `nil` value for this field.