### PR TITLE
Fix non-idiomatic error check

### DIFF
--- a/smt.go
+++ b/smt.go
@@ -138,9 +138,10 @@ func (smt *SparseMerkleTree) HasForRoot(key, root []byte) (bool, error) {
 // Update sets a new value for a key in the tree, and sets and returns the new root of the tree.
 func (smt *SparseMerkleTree) Update(key []byte, value []byte) ([]byte, error) {
 	newRoot, err := smt.UpdateForRoot(key, value, smt.Root())
-	if err == nil {
-		smt.SetRoot(newRoot)
+	if err != nil {
+		return newRoot, err
 	}
+	smt.SetRoot(newRoot)
 	return newRoot, err
 }
 

--- a/smt.go
+++ b/smt.go
@@ -139,7 +139,7 @@ func (smt *SparseMerkleTree) HasForRoot(key, root []byte) (bool, error) {
 func (smt *SparseMerkleTree) Update(key []byte, value []byte) ([]byte, error) {
 	newRoot, err := smt.UpdateForRoot(key, value, smt.Root())
 	if err != nil {
-		return newRoot, err
+		return nil, err
 	}
 	smt.SetRoot(newRoot)
 	return newRoot, err

--- a/smt.go
+++ b/smt.go
@@ -142,7 +142,7 @@ func (smt *SparseMerkleTree) Update(key []byte, value []byte) ([]byte, error) {
 		return nil, err
 	}
 	smt.SetRoot(newRoot)
-	return newRoot, err
+	return newRoot, nil
 }
 
 // Delete deletes a value from tree. It returns the new root of the tree.


### PR DESCRIPTION
Use idiomatic `err != nil` instead of non-idiomatic `err == nil`.