### PR TITLE
Simplify `sideNodesForRoot` function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
             go.mod
             go.sum
       - name: install
-        run: GOOS=linux GOARCH=${{ matrix.goarch }} make build
+        run: GOOS=linux GOARCH=${{ matrix.goarch }} go build
         if: "env.GIT_DIFF != ''"
 
   tests:


### PR DESCRIPTION
This is a suggestion, to simplify the loop in `sideNodesForRoot` in @adlerjohn PR.