### PR TITLE
Remove arm64 from test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goarch: ["arm64", "amd64"]
+        goarch: ["amd64"]
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
GitHub Actions don't have docker containers for ARM architectures. Remove arm64 from test targets (but still build since we can cross-compile).